### PR TITLE
Fix typos: rename Stucture to Structure methods

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.3",
+    "version": "1.3.1",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/HashTableRx.Tests/HashTableRxFixture.cs
+++ b/src/HashTableRx.Tests/HashTableRxFixture.cs
@@ -30,7 +30,7 @@ public class HashTableRxFixture : IDisposable
         Assert.NotNull(obj);
 
         HtRx = new(false);
-        HtRx.SetStucture(obj);
+        HtRx.SetStructure(obj);
     }
 
     /// <summary>

--- a/src/HashTableRx/HashTableRx.cs
+++ b/src/HashTableRx/HashTableRx.cs
@@ -19,6 +19,7 @@ public class HashTableRx : HashTable, IHashTableRx
 {
     private const string PropertyInfo = nameof(PropertyInfo);
     private const string FieldInfo = nameof(FieldInfo);
+    private const string Data = nameof(Data);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HashTableRx" /> class.
@@ -186,7 +187,7 @@ public class HashTableRx : HashTable, IHashTableRx
             return null;
         }
 
-        var data = htrx.Tag?["Data"];
+        var data = htrx.Tag?[Data];
         try
         {
             if (htrx.Tag?[PropertyInfo] != null)
@@ -401,7 +402,7 @@ public class HashTableRx : HashTable, IHashTableRx
             return;
         }
 
-        htrx.Tag!["Data"] = value;
+        htrx.Tag![Data] = value;
         htrx.Tag[FieldInfo] = value.GetType().GetFields();
         htrx.Tag[PropertyInfo] = value.GetType().GetProperties();
         try

--- a/src/HashTableRx/HashTableRxMixins.cs
+++ b/src/HashTableRx/HashTableRxMixins.cs
@@ -113,13 +113,13 @@ public static class HashTableRxMixins
     }
 
     /// <summary>
-    /// Gets the stucture.
+    /// Gets the structure.
     /// </summary>
     /// <param name="this">The this.</param>
     /// <returns>
     /// An object of the current values.
     /// </returns>
-    public static object? GetStucture(this IHashTableRx @this)
+    public static object? GetStructure(this IHashTableRx @this)
     {
         if (@this == null)
         {
@@ -130,11 +130,11 @@ public static class HashTableRxMixins
     }
 
     /// <summary>
-    /// Sets the stucture.
+    /// Sets the structure.
     /// </summary>
     /// <param name="this">The this.</param>
     /// <param name="value">The value.</param>
-    public static void SetStucture(this IHashTableRx @this, object value)
+    public static void SetStructure(this IHashTableRx @this, object value)
     {
         if (@this == null || value == null)
         {


### PR DESCRIPTION
Corrects the spelling of 'Stucture' to 'Structure' in method names and related references across HashTableRx, HashTableRxMixins, and test files. This improves code readability and consistency.