### PR TITLE
Add TwinCAT string array support to HashTableRx

### DIFF
--- a/src/HashTableRx/HashTableRx.cs
+++ b/src/HashTableRx/HashTableRx.cs
@@ -426,7 +426,18 @@ public class HashTableRx : HashTable, IHashTableRx
                     if (propertyInfo.PropertyType?.IsPrimativeArray() == true)
                     {
                         ValueChanging(name);
-                        var obj = propertyInfo.GetValue(value, null);
+                        var obj = default(object);
+                        if (propertyInfo.PropertyType.IsTwinCATStringArray())
+                        {
+                            var arrayOfWrappers = propertyInfo?.GetValue(value);
+                            var toStringArrayMethod = value?.GetType()?.GetMethod("ToStringArray", BindingFlags.Public | BindingFlags.Static);
+                            obj = toStringArrayMethod?.Invoke(null, [arrayOfWrappers]) as string[];
+                        }
+                        else
+                        {
+                            obj = propertyInfo.GetValue(value, null);
+                        }
+
                         htrx[name, true] = obj;
                         ValueChanged(name, obj);
                     }
@@ -455,7 +466,18 @@ public class HashTableRx : HashTable, IHashTableRx
                     if (fieldInfo.FieldType?.IsPrimativeArray() == true)
                     {
                         ValueChanging(name);
-                        var obj = fieldInfo.GetValue(value);
+                        var obj = default(object);
+                        if (fieldInfo.FieldType.IsTwinCATStringArray())
+                        {
+                            var arrayOfWrappers = fieldInfo?.GetValue(value);
+                            var toStringArrayMethod = value?.GetType()?.GetMethod("ToStringArray", BindingFlags.Public | BindingFlags.Static);
+                            obj = toStringArrayMethod?.Invoke(null, [arrayOfWrappers]) as string[];
+                        }
+                        else
+                        {
+                            obj = fieldInfo.GetValue(value);
+                        }
+
                         htrx[name, true] = obj;
                         ValueChanged(name, obj);
                     }

--- a/src/HashTableRx/HashTableRx.csproj
+++ b/src/HashTableRx/HashTableRx.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.0.2" />
   </ItemGroup>
   
 </Project>

--- a/src/HashTableRx/HashTableRxMixins.cs
+++ b/src/HashTableRx/HashTableRxMixins.cs
@@ -19,7 +19,7 @@ public static class HashTableRxMixins
     [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Only type metadata checks; no reflection on members.")]
     public static bool IsPrimativeArray(this Type @this)
     {
-        if (@this?.IsPrimitive == true || @this == typeof(string))
+        if (@this?.IsPrimitive == true || @this == typeof(string) || @this.IsTwinCATStringArray())
         {
             return true;
         }
@@ -32,6 +32,16 @@ public static class HashTableRxMixins
 
         return false;
     }
+
+    /// <summary>
+    /// Determines whether [is twin cat string array].
+    /// </summary>
+    /// <param name="this">The this.</param>
+    /// <returns>
+    ///   <c>true</c> if [is twin cat string array] [the specified this]; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsTwinCATStringArray(this Type? @this) =>
+        @this?.IsArray == true && @this?.Name.Contains("STRING_") == true && @this?.Name.Contains("_WRAPPER") == true;
 
     /// <summary>
     /// Get value of fullName called on scheduler, IObservable length is one.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.1",
+    "version": "2.2",
     "versionHeightPosition": "minor",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",


### PR DESCRIPTION
Introduces IsTwinCATStringArray extension to detect TwinCAT string array wrappers and updates HashTableRx to handle them by converting to string arrays using a ToStringArray method. Also updates System.Reactive to 6.0.2 and bumps version to 2.2.